### PR TITLE
Add Type Support

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,26 @@
+import * as React from "react";
+interface ToggleProps
+  extends React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement> {
+  id?: string | undefined;
+  name?: string | undefined;
+  label?: string | undefined;
+  labelRight?: string | undefined;
+  className?: string | undefined;
+  checked: boolean;
+  defaultChecked?: boolean | undefined;
+  mode?: "toggle" | "switch" | "select";
+  theme?: "round" | "square" | undefined;
+  disabled?: boolean | undefined;
+  onToggle?: (newState: boolean, event: React.ChangeEvent<HTMLInputElement>) => void | undefined;
+}
+interface ToggleState {
+  checked: boolean;
+}
+declare class Toggle extends React.Component<ToggleProps, ToggleState> {
+  public displayName: string;
+  private onToggle;
+  constructor(propublic ps: ToggleProps);
+  rendepublic r(): JSX.Element;
+  componentWillReceiveProps(nextProps: ToggleProps): void;
+}
+export default Toggle;

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": false,
   "description": "A React UI Component to display an awesome Toggle Button control",
   "main": "dist/index.js",
+  "types": "index.d.ts",
   "keywords": [
     "toggle",
     "component",
@@ -25,7 +26,8 @@
     "prepublishOnly": "npm run transpile",
     "build": "webpack --mode production",
     "deploy": "gh-pages -d examples/dist",
-    "publish-demo": "npm run build && npm run deploy"
+    "publish-demo": "npm run build && npm run deploy",
+    "update-types": "tsc src/index.js --declaration --jsx react --emitDeclarationOnly"
   },
   "author": "Giovambattista Fazioli",
   "license": "MIT",


### PR DESCRIPTION
I thought it best to remove the backwards compatibility props from the types because it made the types ugly and would require changes to src/index.js since `onChange` could send through to the `div`.