### PR TITLE
Update peer dependencies to React 17

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,8 +51,8 @@
     "styled-components": "^4.2.0"
   },
   "peerDependencies": {
-    "react": "^16.8.6",
-    "react-dom": "^16.8.6",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2",
     "styled-components": "^4.2.0"
   },
   "dependencies": {


### PR DESCRIPTION
Fixes #52

Update the peer dependencies for React and React-DOM to version 17.0.2.

* Update the `peerDependencies` section in the `package.json` file to list `react` as `^17.0.2`.
* Update the `peerDependencies` section in the `package.json` file to list `react-dom` as `^17.0.2`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/gfazioli/react-toggle/pull/61?shareId=0ad24d10-a0de-4bd1-9fb4-366f8efbc859).