### PR TITLE
Fix event target type in onToggle event

### DIFF
--- a/src/components/Toggle/index.tsx
+++ b/src/components/Toggle/index.tsx
@@ -40,17 +40,17 @@ interface Props {
   /**
    * Trigged when the toggle change
    *
-   * @param {React.ChangeEvent} e
+   * @param {React.ChangeEvent<HTMLInputElement>} e
    */
-  onToggle?: (e: React.ChangeEvent) => void;
+  onToggle?: (e: React.ChangeEvent<HTMLInputElement>) => void;
   /**
    * Trigged when the toggle is on the left.
    */
-  onRight?: (e: React.ChangeEvent) => void;
+  onRight?: (e: React.ChangeEvent<HTMLInputElement>) => void;
   /**
    * Trigged when the toggle is on the right.
    */
-  onLeft?: (e: React.ChangeEvent) => void;
+  onLeft?: (e: React.ChangeEvent<HTMLInputElement>) => void;
 
   // ---------------------------------------------------------------
   // Appearance
@@ -301,13 +301,11 @@ const Toggle: FunctionComponent<Props> = (props, ref) => {
 
   const cls = ["react-toggle", className || ""].join(" ");
 
-  const onChangeHandler = (e: React.ChangeEvent) => {
+  const onChangeHandler = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (!!onToggle) {
       onToggle(e);
 
-      const target = e.target as HTMLInputElement;
-
-      if (target && target.checked) {
+      if (e.target && e.target.checked) {
         onRight(e);
       } else {
         onLeft(e);


### PR DESCRIPTION
Fixes #33

Update the `onToggle` event type to `React.ChangeEvent<HTMLInputElement>` in `src/components/Toggle/index.tsx`.

* Update the `onToggle` event type in the `Props` interface.
* Update the `onRight` event type in the `Props` interface.
* Update the `onLeft` event type in the `Props` interface.
* Remove the cast to `HTMLInputElement` in the `onChangeHandler` function.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/gfazioli/react-toggle/pull/62?shareId=08bb07fb-4413-45bf-a334-8393aee61cbb).